### PR TITLE
Added USERNAME variable in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,4 +213,18 @@ Submit a fine-tuning job to SLURM directly from your local machine:
 ```bash
 ./run_on_cluster.sh beluga +action=train +preset=base/run_on_cluster.sh beluga +action=train +preset=base
 ```
+## License
 
+Copyright (C) 2024 g33kex, Kkameleon, ran-ya, yberreby
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+We are not affiliated with the Digital Research Alliance of Canada.

--- a/config.sh
+++ b/config.sh
@@ -3,15 +3,17 @@
 ## Settings
 # Name of the repository (change this to the name of your project)
 REPO_NAME="CoCPyT"
+# Username on compute canada (change this if it's different than your local username)
+USERNAME="${USER}"
 # Which modules to load (change this if you need other modules or versions)
 MODULES="StdEnv/2023 python/3.11.5 arrow/15.0.1 cuda/12.2 httpproxy/1.0"
 
 ## Default paths (change only if you know what you're doing)
 # Where to store the git repo on CC
-REPO_PATH="${HOME}/scratch/${REPO_NAME}"
+REPO_PATH="/home/${USERNAME}/scratch/${REPO_NAME}"
 # Where to extract the venv. This path must be accessible on both the login node and the compute node.
 # It is recommended to use fast storage like /tmp or /localscratch
-VENV_PATH="/tmp/${USER}/${REPO_NAME}"
+VENV_PATH="/tmp/${USERNAME}/${REPO_NAME}"
 # Where to store the venv tar (should be persistent storage)
 VENV_TAR_PATH="${REPO_PATH}/venv.tar.gz"
 # Location of the cluster requirements file


### PR DESCRIPTION
Username on Compute Canada can now be specified in `config.sh` with the variable `USERNAME` in case it is different from your local username. Fixes #1.

License notice was added to credit the original contributors of the early code base of this project. Fixes #2.